### PR TITLE
Use Ubuntu 17:10 for build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM ubuntu:17.04
-LABEL name="hyperterm-hardware-dev" \
+FROM ubuntu:17.10
+LABEL name="hyperterm-hardware" \
       version="0.1.0"
 MAINTAINER Mike Wild <mike@mikeanthonywild.com>
 
@@ -8,9 +8,6 @@ ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 ENV LANGUAGE=C.UTF-8
 
-RUN apt-get update -y && \
-    apt-get install -y software-properties-common && \
-    add-apt-repository ppa:mikewild/ngspice-shared
 # Installing KiCad from PPA times out build for some reason.
 # Disable this and install from Ubuntu repos for time being...
 #RUN add-apt-repository ppa:js-reynaud/kicad-4
@@ -20,40 +17,34 @@ RUN apt-get update -y && \
 # invalidates the cache when we add a new package.
 RUN apt-get update -y && \
     apt-get install -y \
-	ngspice=26-1.1ubuntu4 \
-	kicad=4.0.5+dfsg1-4 \
-        python3=3.5.3-1 \
+        wget=1.19.1-3ubuntu1.1 \
+        kicad=4.0.6+dfsg1-1 \
+        python3=3.6.3-0ubuntu2 \
         python3-pip=9.0.1-2 \
-        python3-tk=3.5.3-1ubuntu1 \
-	nodejs=4.7.2~dfsg-1ubuntu3 \
-	npm=3.5.2-0ubuntu4 \
-	ruby-full=1:2.3.3 \
-        && \
+        python3-tk=3.6.3-0ubuntu1 \
+        nodejs=6.11.4~dfsg-1ubuntu1 \
+        npm=3.5.2-0ubuntu4 \
+        ruby-full=1:2.3.3 \
+    && \
     pip3 install \
-	PyTest==3.2.5 \
+        PyTest==3.2.5 \
         PySpice==1.1.3 \
         Sphinx==1.6.5 \
-	Flake8==3.5.0 \
-	# These are required since PySpice doesn't list its dependencies
-	# https://github.com/FabriceSalvaire/PySpice/issues/84
-	# TODO: Check for new release of PySpice
-        PyYAML==3.12 \
-        cffi==1.11.2 \
-        matplotlib==2.1.0 \
-        numpy==1.13.3 \
-        scipy==1.0.0 \
-	&& \
+        Flake8==3.5.0 \
+    && \
     npm install -g \
-	dockerfile_lint@0.2.7 \
-	&& \
+        dockerfile_lint@0.2.7 \
+    && \
     gem install --no-rdoc --no-ri \
-	travis:1.8.8 \
-	&& \
+        travis:1.8.8 \
+    && \
     # Cleanup
     rm -rf ~/.cache/pip/* && gem cleanup && apt-get clean
 
-# Fix required to provide node bin
-RUN ln -s /usr/bin/nodejs /usr/bin/node
+# Pushing out a new release for 17:10 via Launchpad is too
+# time consuming, so just isntall straight from the .deb...
+RUN wget https://launchpad.net/~mikewild/+archive/ubuntu/ngspice-shared/+build/13749894/+files/ngspice_26-1.1ubuntu4_amd64.deb && \
+    dpkg -i ngspice_26-1.1ubuntu4_amd64.deb
 
 # Drop the user into project directory
 WORKDIR /workspace


### PR DESCRIPTION
Closes #16 

Update Dockerfile base to Ubuntu 17:10 and re-pin packages. Didn't rebuild ngspice on Launchpad as it was too time consuming. We wget the previous package and install the .deb directly instead.